### PR TITLE
Options for "freetype:shared" can only be upper case True or False

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you handle multiple dependencies in your project is better to add a *conanfil
     freetype/2.0.3@lasote/stable
 
     [options]
-    freetype:shared=true # false
+    freetype:shared=True # False
     
     [generators]
     txt


### PR DESCRIPTION
Edited readme.md to reflect the allowed  values for ```freetype:shared``` being only "True" and "False". Lowercase true and false as done below give an error.

## conanfile.txt
```
[requires]
freetype/2.6.3@lasote/stable

[options]
freetype:shared=false

[generators]
cmake
```

## Command
```
[hak8or@mzz truefalse]$ conan install .
ERROR: freetype/2.6.3@lasote/stable: 'true' is not a valid 'options.shared' value.
Possible values are ['False', 'True']
```
```
[hak8or@mzz truefalse]$ conan install .
ERROR: freetype/2.6.3@lasote/stable: 'false' is not a valid 'options.shared' value.
Possible values are ['False', 'True']
```

## Conan version
```
[hak8or@mzz truefalse]$ conan --version
Conan version 0.17.1
```